### PR TITLE
(fix) Remove RG parameter from lighthouse connection deployment since…

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -393,7 +393,6 @@
             "name": "enableXDRLighthouseConnection",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
-            "resourceGroup": "[parameters('rgName')]",
             "dependsOn": [
                 "workspaceCreation"
             ],


### PR DESCRIPTION
… it's deployed at the subscription level